### PR TITLE
Fix return type of Presenter::make().

### DIFF
--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -79,7 +79,7 @@ abstract class Presenter implements ArrayAccess, Arrayable, Jsonable
      *
      * @param Model $model
      * @param \Hemp\Presenter\Presenter|null $presenter
-     * @return void
+     * @return \Hemp\Presenter\Presenter
      */
     public static function make(Model $model, $presenter = null)
     {


### PR DESCRIPTION
Using this package in a project with PHPStan throws up errors whenever we use the `make` static method on a presenter that extends the abstract `Presenter` class—it's currently marked as void.